### PR TITLE
Rewrite the Canonical CBOR section to prefer lexicographic ordering.

### DIFF
--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -637,7 +637,7 @@ are encoded in the additional bytes of the appropriate size.  (See
 
 An encoder
 MUST NOT encode False as the two-byte sequence of 0xf814,
-MUST NOT encode True as the two-byte sequence of 0xf815, 
+MUST NOT encode True as the two-byte sequence of 0xf815,
 MUST NOT encode Null as the two-byte sequence of 0xf816, and
 MUST NOT encode Undefined value as the two-byte sequence of 0xf817.
 A decoder MUST treat these two-byte sequences as an error.
@@ -1281,64 +1281,98 @@ Some protocols may want encoders to only emit CBOR in a particular
 canonical format; those protocols might also have the decoders check
 that their input is canonical. Those protocols are free to define what
 they mean by a canonical format and what encoders and decoders are
-expected to do. This section lists some suggestions for such
-protocols.
+expected to do. This section defines a set of restrictions that can
+serve as the base of such a canonical format.
 
-If a protocol considers "canonical" to mean that two encoder
-implementations starting with the same input data will produce the
-same CBOR output, the following four rules would suffice:
+A CBOR encoding satisfies the "core canonicalization requirements" if
+it satisfies the following restrictions:
 
-* Integers must be as small as possible.
+* Integers MUST be as short as possible. In particular:
 
-  * 0 to 23 and -1 to -24 must be expressed in the same byte as the
+  * 0 to 23 and -1 to -24 MUST be expressed in the same byte as the
     major type;
 
-  * 24 to 255 and -25 to -256 must be expressed only with an
+  * 24 to 255 and -25 to -256 MUST be expressed only with an
     additional uint8_t;
 
-  * 256 to 65535 and -257 to -65536 must be expressed only with an
+  * 256 to 65535 and -257 to -65536 MUST be expressed only with an
     additional uint16_t;
 
-  * 65536 to 4294967295 and -65537 to -4294967296 must be expressed
+  * 65536 to 4294967295 and -65537 to -4294967296 MUST be expressed
     only with an additional uint32_t.
 
-* The expression of lengths in major types 2 through 5 must be as
+* The expression of lengths in major types 2 through 5 MUST be as
   short as possible. The rules for these lengths follow the above rule
   for integers.
 
-* The keys in every map must be sorted lowest value to
-  highest. Sorting is performed on the bytes of the representation of
-  the key data items without paying attention to the 3/5 bit splitting
-  for major types.  (Note that this rule allows maps that have keys of
-  different types, even though that is probably a bad practice that
-  could lead to errors in some canonicalization implementations.) The
-  sorting rules are:
+* The keys in every map MUST be sorted in the bytewise lexicographic
+  order of their canonical encodings. For example, the following keys
+  are sorted correctly:
 
-  * If two keys have different lengths, the shorter one sorts earlier;
+  1. 10, encoded as 0x0a.
+  1. 100, encoded as 0x1864.
+  1. -1, encoded as 0x20.
+  1. "z", encoded as 0x617a.
+  1. "aa", encoded as 0x626161.
+  1. \[100], encoded as 0x811864.
+  1. \[-1], encoded as 0x8120.
+  1. false, encoded as 0xf4.
 
-  * If two keys have the same length, the one with the lower value in
-    (byte-wise) lexical order sorts earlier.
+* Indefinite-length items MUST not appear. They can be encoded as
+  definite-length items instead.
 
-* Indefinite-length items must be made into definite-length items.
+Protocols that include floating, big integer, or other complex values
+need to define extra requirements on their canonical encodings. For
+example:
 
-If a protocol allows for IEEE floats, then additional canonicalization
-rules might need to be added.  One example rule might be to have all
-floats start as a 64-bit float, then do a test conversion to a 32-bit
-float; if the result is the same numeric value, use the shorter value
-and repeat the process with a test conversion to a 16-bit float. (This
-rule selects 16-bit float for positive and negative Infinity as well.)
-Also, there are many representations for NaN. If NaN is an allowed
-value, it must always be represented as 0xf97e00.
+* If a protocol includes a field that can express floating values
+  ({{fpnocont}}), the protocol's canonicalization needs to specify
+  whether the integer 1.0 is encoded as 0x01, 0xf93c00, 0xfa3f800000,
+  or 0xfb3ff0000000000000. Two sensible rules for this are:
+  1. Encode integral values that fit in 64 bits as values from major
+     types 0 and 1, and other values as the smallest of 16-, 32-, or
+     64-bit floating point that accurately represents the value, or
+  1. Encode all values as 64-bit floating point.
 
-CBOR tags present additional considerations for canonicalization. The
-absence or presence of tags in a canonical format is determined by the
-optionality of the tags in the protocol. In a CBOR-based protocol that
-allows optional tagging anywhere, the canonical format must not allow
-them.  In a protocol that requires tags in certain places, the tag
-needs to appear in the canonical format. A CBOR-based protocol that
-uses canonicalization might instead say that all tags that appear in a
-message must be retained regardless of whether they are optional.
+  If NaN is an allowed value, the protocol needs to pick a single
+  representation, for example 0xf97e00.
+* If a protocol includes a field that can express integers larger than
+  2^64 using tag 2 ({{bignums}}), the protocol's canonicalization
+  needs to specify whether small integers are expressed using the tag
+  or major types 0 and 1.
+* A protocol might give encoders the choice of representing a URL as
+  either a text string or, using {{encodedtext}}, tag 32 containing a
+  text string. This protocol's canonicalization needs to either
+  require that the tag is present or require that it's absent, not
+  allow either one.
 
+### Length-first map key ordering
+
+The core canonicalization requirements sort map keys in a different
+order from the one suggested by {{?RFC7049}}. Protocols that need to
+be compatible with {{?RFC7049}}'s order can instead be specified in
+terms of this specification's "length-first core canonicalization
+requirements":
+
+A CBOR encoding satisfies the "length-first core canonicalization
+requirements" if it satisfies the core canonicalization requirements
+except that the keys in every map MUST be sorted such that:
+
+1. If two keys have different lengths, the shorter one sorts earlier;
+1. If two keys have the same length, the one with the lower value in
+   (byte-wise) lexical order sorts earlier.
+
+For example, under the length-first core canonicalization
+requirements, the following keys are sorted correctly:
+
+1. 10, encoded as 0x0a.
+1. -1, encoded as 0x20.
+1. false, encoded as 0xf4.
+1. 100, encoded as 0x1864.
+1. "z", encoded as 0x617a.
+1. \[-1], encoded as 0x8120.
+1. "aa", encoded as 0x626161.
+1. \[100], encoded as 0x811864.
 
 ## Strict Mode {#strict-mode}
 

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -1328,10 +1328,13 @@ example:
 * If a protocol includes a field that can express floating values
   ({{fpnocont}}), the protocol's canonicalization needs to specify
   whether the integer 1.0 is encoded as 0x01, 0xf93c00, 0xfa3f800000,
-  or 0xfb3ff0000000000000. Two sensible rules for this are:
+  or 0xfb3ff0000000000000. Three sensible rules for this are:
   1. Encode integral values that fit in 64 bits as values from major
      types 0 and 1, and other values as the smallest of 16-, 32-, or
-     64-bit floating point that accurately represents the value, or
+     64-bit floating point that accurately represents the value,
+  1. Encode all values as the smallest of 16-, 32-, or 64-bit floating
+     point that accurately represents the value, even for integral
+     values, or
   1. Encode all values as 64-bit floating point.
 
   If NaN is an allowed value, the protocol needs to pick a single


### PR DESCRIPTION
And to be clearer about the extra work protocols need to do in order
to support floating point and tags.

This also provides some examples of map key sorting.

I believe this change is consistent with the discussion in https://www.ietf.org/mail-archive/web/cbor/current/msg00264.html.