### PR TITLE
Improve the data model specification.

### DIFF
--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -340,8 +340,7 @@ of a number of simple values and tags right in this document, such as:
 * `false`, `true`, `null`, and `undefined` (simple values identified by 20..23)
 * integer and floating point values with a larger range and precision
   than the above (tags 2 to 5)
-* application data types such as a point in time or an RFC 3339
-  date/time string (tags 1, 0)
+* application data types such as a point in time (tags 1, 0)
 
 Further elements of the extended generic data model can be (and have
 been) defined via the IANA registries created for CBOR.  Even if such
@@ -793,6 +792,9 @@ the rest of this section.
 
 ### Date and Time {#datetimesect}
 
+Protocols using tag values 0 and 1 extend the generic data model
+({{cbor-data-models}}) with data items representing points in time.
+
 Tag value 0 is for date/time strings that follow the standard format
 described in {{RFC3339}}, as refined by Section 3.3 of {{RFC4287}}.
 
@@ -809,13 +811,17 @@ number, indicate fractional seconds.
 
 ### Bignums {#bignums}
 
-Bignums are integers that do not fit into the basic integer
-representations provided by major types 0 and 1.  They are encoded as
-a byte string data item, which is interpreted as an unsigned integer n
-in network byte order.  For tag value 2, the value of the bignum is n.
-For tag value 3, the value of the bignum is -1 - n.  Decoders that
-understand these tags MUST be able to decode bignums that have leading
-zeroes.
+Protocols using tag values 2 and 3 extend the generic data model
+({{cbor-data-models}}) with "bignums" representing arbitrary
+integers. In the generic data model, bignum values are not equal to
+integers from the basic data model, but specific data models can
+define that equivalence.
+
+Bignums are encoded as a byte string data item, which is interpreted
+as an unsigned integer n in network byte order.  For tag value 2, the
+value of the bignum is n.  For tag value 3, the value of the bignum is
+-1 - n.  Decoders that understand these tags MUST be able to decode
+bignums that have leading zeroes.
 
 For example, the number 18446744073709551616 (2\*\*64) is represented
 as 0b110_00010 (major type 6, tag 2), followed by 0b010_01001 (major
@@ -831,6 +837,13 @@ C2                        -- Tag 2
 
 
 ### Decimal Fractions and Bigfloats {#fractions}
+
+Protocols using tag value 4 extend the generic data model with data
+items representing arbitrary-length decimal fractions m*(10**e).
+Protocols using tag value 5 extend the generic data model with data
+items representing arbitrary-length binary fractions m*(2**e). As with
+bignums, values of different types are not equal in the generic data
+model.
 
 Decimal fractions combine an integer mantissa with a base-10 scaling
 factor.  They are most useful if an application needs the exact
@@ -899,7 +912,8 @@ that the integer representation is used directly.
 ### Content Hints
 
 The tags in this section are for content hints that might be used by
-generic CBOR processors.
+generic CBOR processors. These content hints do not extend the generic
+data model.
 
 #### Encoded CBOR Data Item {#embedded-di}
 

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -332,6 +332,8 @@ In the basic (un-extended) generic data model, a data item is one of:
 Note that integer and floating-point values are distinct in this
 model, even if they have the same numeric value.
 
+## Extended generic data models
+
 This basic generic data model comes pre-extended by the registration
 of a number of simple values and tags right in this document, such as:
 
@@ -359,14 +361,26 @@ their programming environment, implementation of the data model
 extensions created by tags is truly optional and a matter of
 implementation quality.
 
-A specific data model usually subsets the extended generic data model
-and assigns application semantics to the data items within this subset
-and its components.  When documenting such specific data models,
-where it is desired to specify the types of data items, it is
-preferred to identify the types by their names in the generic data
-model ("negative integer", "array") instead of by referring to aspects
-of their CBOR representation ("major type 1", "major type 4").
+## Specific data models
 
+The specific data model for a CBOR-based protocol usually subsets the
+extended generic data model and assigns application semantics to the
+data items within this subset and its components.  When documenting
+such specific data models, where it is desired to specify the types of
+data items, it is preferred to identify the types by their names in
+the generic data model ("negative integer", "array") instead of by
+referring to aspects of their CBOR representation ("major type 1",
+"major type 4").
+
+Specific data models can also specify that values of different types
+are equivalent for the purposes of map keys and encoder freedom. For
+example, in the generic data model, a valid map MAY have both `0` and
+`0.0` as keys, and an encoder MUST NOT encode `0.0` as an integer
+(major type 0, {{majortypes}}).  However, if a specific data model
+declares that floating point and integer representations of integral
+values are equivalent, map keys `0` and `0.0` would be considered
+duplicates and so invalid, and an encoder could encode integral-valued
+floats as integers or vice versa, perhaps to save encoded bytes.
 
 # Specification of the CBOR Encoding
 
@@ -1173,14 +1187,6 @@ item only to the application, or take some other type of action.
 
 
 ## Numbers {#numbers}
-
-For the purposes of this specification, all number representations for
-the same numeric value are equivalent.  This means that an encoder can
-encode a floating-point value of 0.0 as the integer 0.  It, however,
-also means that an application that expects to find integer values
-only might find floating-point values if the encoder decides these are
-desirable, such as when the floating-point value is more compact than
-a 64-bit integer.
 
 An application or protocol that uses CBOR might restrict the
 representations of numbers.  For instance, a protocol that only deals

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -298,6 +298,75 @@ emphasize the desired interpretation of the bits in the byte; in this
 case, it is split into three bits and five bits.
 
 
+# CBOR Data Models
+
+CBOR is explicit about its generic data model, which defines the set
+of all data items that can be represented in CBOR.  Its basic generic
+data model is extensible by the registration of simple type values and
+tags.  Applications can then subset the resulting extended generic
+data model to build their specific data models.
+
+Within environments that can represent the data items in the generic
+data model, generic CBOR encoders and decoders can be implemented
+(which usually involves defining additional implementation data types
+for those data items that do not already have a natural representation
+in the environment).  The ability to provide generic encoders and
+decoders is an explicit design goal of CBOR; however many applications
+will provide their own application-specific encoders and/or decoders.
+
+In the basic (un-extended) generic data model, a data item is one of:
+
+* an integer in the range -2\*\*64..2\*\*64-1 inclusive
+* a simple value, identified by a number
+  between 0 and 255, but distinct from that number
+* a floating point value, distinct from an integer, out of the set
+  representable by IEEE 754 binary64 (including non-finites)
+* a sequence of zero or more bytes ("byte string")
+* a sequence of zero or more Unicode code points ("text string")
+* a sequence of zero or more data items ("array")
+* a mapping (mathematical function) from zero or more data items
+  ("keys") each to a data item ("values"), ("map")
+* a tagged data item, comprising a tag (an integer in the range
+  0..2\*\*64-1) and a value (a data item)
+
+Note that integer and floating-point values are distinct in this
+model, even if they have the same numeric value.
+
+This basic generic data model comes pre-extended by the registration
+of a number of simple values and tags right in this document, such as:
+
+* `false`, `true`, `null`, and `undefined` (simple values identified by 20..23)
+* integer and floating point values with a larger range and precision
+  than the above (tags 2 to 5)
+* application data types such as a point in time or an RFC 3339
+  date/time string (tags 1, 0)
+
+Further elements of the extended generic data model can be (and have
+been) defined via the IANA registries created for CBOR.  Even if such
+an extension is unknown to a generic encoder or decoder, data items
+using that extension can be passed to or from the application by
+representing them at the interface to the application within the basic
+generic data model, i.e., as generic values of a simple type or
+generic tagged items.
+
+In other words, the basic generic data model is stable as defined in
+this document, while the extended generic data model expands by the
+registration of new simple values or tags, but never shrinks.
+
+While there is a strong expectation that generic encoders and decoders
+can represent `false`, `true`, and `null` in the form appropriate for
+their programming environment, implementation of the data model
+extensions created by tags is truly optional and a matter of
+implementation quality.
+
+A specific data model usually subsets the extended generic data model
+and assigns application semantics to the data items within this subset
+and its components.  When documenting such specific data models,
+where it is desired to specify the types of data items, it is
+preferred to identify the types by their names in the generic data
+model ("negative integer", "array") instead of by referring to aspects
+of their CBOR representation ("major type 1", "major type 4").
+
 
 # Specification of the CBOR Encoding
 
@@ -899,75 +968,6 @@ JSON. Such a decoder would need to mechanically distinguish the two
 formats. An easy way for an encoder to help the decoder would be to
 tag the entire CBOR item with tag 55799, the serialization of which
 will never be found at the beginning of a JSON text.
-
-## CBOR Data Models
-
-CBOR is explicit about its generic data model, which defines the set
-of all data items that can be represented in CBOR.  Its basic generic
-data model is extensible by the registration of simple type values and
-tags.  Applications can then subset the resulting extended generic
-data model to build their specific data models.
-
-Within environments that can represent the data items in the generic
-data model, generic CBOR encoders and decoders can be implemented
-(which usually involves defining additional implementation data types
-for those data items that do not already have a natural representation
-in the environment).  The ability to provide generic encoders and
-decoders is an explicit design goal of CBOR; however many applications
-will provide their own application-specific encoders and/or decoders.
-
-In the basic (un-extended) generic data model, a data item is one of:
-
-* an integer in the range -2\*\*64..2\*\*64-1 inclusive
-* a simple value, identified by a number
-  between 0 and 255, but distinct from that number
-* a floating point value, distinct from an integer, out of the set
-  representable by IEEE 754 binary64 (including non-finites)
-* a sequence of zero or more bytes ("byte string")
-* a sequence of zero or more Unicode code points ("text string")
-* a sequence of zero or more data items ("array")
-* a mapping (mathematical function) from zero or more data items
-  ("keys") each to a data item ("values"), ("map")
-* a tagged data item, comprising a tag (an integer in the range
-  0..2\*\*64-1) and a value (a data item)
-
-Note that integer and floating-point values are distinct in this
-model, even if they have the same numeric value.
-
-This basic generic data model comes pre-extended by the registration
-of a number of simple values and tags right in this document, such as:
-
-* `false`, `true`, `null`, and `undefined` (simple values identified by 20..23)
-* integer and floating point values with a larger range and precision
-  than the above (tags 2 to 5)
-* application data types such as a point in time or an RFC 3339
-  date/time string (tags 1, 0)
-
-Further elements of the extended generic data model can be (and have
-been) defined via the IANA registries created for CBOR.  Even if such
-an extension is unknown to a generic encoder or decoder, data items
-using that extension can be passed to or from the application by
-representing them at the interface to the application within the basic
-generic data model, i.e., as generic values of a simple type or
-generic tagged items.
-
-In other words, the basic generic data model is stable as defined in
-this document, while the extended generic data model expands by the
-registration of new simple values or tags, but never shrinks.
-
-While there is a strong expectation that generic encoders and decoders
-can represent `false`, `true`, and `null` in the form appropriate for
-their programming environment, implementation of the data model
-extensions created by tags is truly optional and a matter of
-implementation quality.
-
-A specific data model usually subsets the extended generic data model
-and assigns application semantics to the data items within this subset
-and its components.  When documenting such specific data models,
-where it is desired to specify the types of data items, it is
-preferred to identify the types by their names in the generic data
-model ("negative integer", "array") instead of by referring to aspects
-of their CBOR representation ("major type 1", "major type 4").
 
 
 # Creating CBOR-Based Protocols

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -370,8 +370,9 @@ of their CBOR representation ("major type 1", "major type 4").
 
 # Specification of the CBOR Encoding
 
-A CBOR-encoded data item is structured and encoded as described in
-this section.  The encoding is summarized in {{jumptable}}.
+A CBOR data item  ({{cbor-data-models}}) is encoded to or decoded from
+a byte string as described in this section.  The encoding is
+summarized in {{jumptable}}.
 
 The initial byte of each data item contains both information about the
 major type (the high-order 3 bits, described in {{majortypes}}) and


### PR DESCRIPTION
This is mostly editorial, except that it picks a resolution to the normative conflict between the current data model section saying "integer and floating-point values are distinct in this model" and the numbers section saying "all number representations for the same numeric value are equivalent".