### PR TITLE
Clearly identify ill-formed and invalid items, and specify processor behavior on them

### DIFF
--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -409,7 +409,7 @@ floats as integers or vice versa, perhaps to save encoded bytes.
 
 A CBOR data item  ({{cbor-data-models}}) is encoded to or decoded from
 a byte string as described in this section.  The encoding is
-summarized in {{jumptable}}.  An encoder MUST produce only valid
+summarized in {{jumptable}}.  An encoder MUST produce only well-formed
 items.  A decoder MUST stop and return an error with no data when it
 encounters a non-well-formed item.
 
@@ -1091,7 +1091,8 @@ pair whose key is 0xab01".
 
 CBOR-based protocols MUST specify how their decoders handle
 invalid and other unexpected data.  CBOR-based protocols
-MAY specify that they treat arbitrary valid data as unexpected.  An
+MAY specify that they treat arbitrary valid data as unexpected.
+Encoders for CBOR-based protocols MUST produce only valid items. An
 encoder can be capable of encoding as many or as few types of values
 as is required by the protocol in which it is used; a decoder can be
 capable of understanding as many or as few types of values as is

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -287,7 +287,7 @@ Well-formed:
 : A data item that follows the syntactic structure of CBOR.  A
   well-formed data item uses the initial bytes and the byte strings
   and/or data items that are implied by their values as defined in
-  CBOR and is not followed by extraneous data. CBOR parsers only
+  CBOR and is not followed by extraneous data. CBOR decoders only
   return contents from well-formed data items.
 
 Valid:
@@ -423,12 +423,12 @@ Less than 24:
 : The argument's value is the value of the additional information.
 
 24, 25, 26, or 27:
-: The argument's value is held in the following 1, 2, 4, or 8,
-  respectively, bytes, in network byte order.
+: The argument's value is held in the following 1, 2, 4, or 8 bytes,
+  respectively, in network byte order.
 
 28, 29, 30:
-: These values are reserved for future expansion.  In this version of
-  CBOR, the encoded item is not well-formed.
+: These values are reserved for future additions to the CBOR format.
+  In this version of CBOR, the encoded item is not well-formed.
 
 31:
 : If the major type is 0, 1, or 6, the encoded item is
@@ -445,8 +445,9 @@ determine the number of data items enclosed.
 If the encoded sequence of bytes ends before the end of a data item,
 that item is not well-formed. If the encoded
 sequence of bytes still has bytes remaining
-after the outermost encoded item is decoded, that outer item is
-not well-formed.
+after the outermost encoded item is decoded, the decoder MAY either
+treat that outer item as not well-formed or just identify the start of
+the remaining bytes.
 
 A CBOR decoder implementation can be based on a jump table with all
 256 defined values for the initial byte ({{jumptable}}).  A decoder in
@@ -720,7 +721,7 @@ information is in the initial bytes.
 |          25 | IEEE 754 Half-Precision Float (16 bits follow)            |
 |          26 | IEEE 754 Single-Precision Float (32 bits follow)          |
 |          27 | IEEE 754 Double-Precision Float (64 bits follow)          |
-|       28-30 | Unassigned, currently not well-formed                     |
+|       28-30 | Unassigned, not well-formed now                           |
 |          31 | "break" stop code for indefinite-length items ({{break}}) |
 {: #fpnoconttbl title='Values for Additional Information in Major Type 7'}
 
@@ -1132,12 +1133,12 @@ A generic CBOR decoder can decode all well-formed CBOR data and
 present them to an application.  See {{pseudocode}}.
 
 Even though CBOR attempts to minimize these cases, not all well-formed
-CBOR data is valid: for example, the text string `0x62c0ae` is not
-valid UTF-8 and so not a valid CBOR item.  Also, specific tags may
+CBOR data is valid: for example, the encoded text string `0x62c0ae` is
+not valid UTF-8 and so not a valid CBOR item.  Also, specific tags may
 make semantic constraints that may be violated, such as a bignum tag
-containing another tag, or a date tag containing a byte string or a
-text string with contents that don't match {{RFC3339}}'s `date-time`
-production.  There is
+containing another tag, or an instance of tag 0 containing a byte
+string or a text string with contents that don't match {{RFC3339}}'s
+`date-time` production.  There is
 no requirement that generic encoders and decoders make unnatural
 choices for their application interface to enable the processing of
 invalid data.  Generic encoders and decoders are expected to forward

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -1280,12 +1280,19 @@ floating-point keys the values of which happen to be integer numbers in the same
 Decoders that deliver data items nested within a CBOR data item
 immediately on decoding them ("streaming decoders") often do not keep
 the state that is necessary to ascertain uniqueness of a key in a map.
-In this case, the surrounding application is responsible for satisfying
-the requirement that an non-well-formed map with duplicate keys is rejected.
 Similarly, an encoder that can start encoding data items before the
 enclosing data item is completely available ("streaming encoder") may
 want to reduce its overhead significantly by relying on its data
 source to maintain uniqueness.
+
+A CBOR-based protocol MUST define what
+to do when a receiving application does see multiple identical keys in
+a map.  The resulting rule in the protocol MUST respect the CBOR
+data model: it cannot prescribe a specific handling of the entries
+with the identical keys, except that it might have a rule that having
+identical keys in a map indicates a malformed map and that the decoder
+has to stop with an error. Duplicate keys are also prohibited by CBOR
+decoders that are using strict mode ({{strict-mode}}).
 
 The CBOR data model for maps does not allow ascribing semantics to the
 order of the key/value pairs in the map representation.  Thus, a
@@ -1553,6 +1560,8 @@ the effort to reliably detect invalid data items
 ({{semantic-errors}}). For example, a strict decoder needs to have an
 API that reports an error (and does not return data) for a CBOR data
 item that contains any of the following:
+
+* a map (major type 5) that has more than one entry with the same key
 
 * a tag that is used on a data item of the incorrect type
 

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -720,7 +720,7 @@ information is in the initial bytes.
 |          25 | IEEE 754 Half-Precision Float (16 bits follow)            |
 |          26 | IEEE 754 Single-Precision Float (32 bits follow)          |
 |          27 | IEEE 754 Double-Precision Float (64 bits follow)          |
-|       28-30 | Not well-formed                                           |
+|       28-30 | Unassigned, currently not well-formed                     |
 |          31 | "break" stop code for indefinite-length items ({{break}}) |
 {: #fpnoconttbl title='Values for Additional Information in Major Type 7'}
 


### PR DESCRIPTION
This heavily rewords the definition of additional data and the item's unsigned
integer. It also moves some content from section 4 (Creating CBOR-Based
Protocols) into the main specification when it was actually describing when
data is invalid or ill-formed.

This does not yet clarify when tagged values are invalid.

Fixes #3.