### PR TITLE
Forbid CBOR-based protocols from depending on mapping order.

### DIFF
--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -1342,9 +1342,9 @@ has to stop with an error. Duplicate keys are also prohibited by CBOR
 decoders that are using strict mode ({{strict-mode}}).
 
 The CBOR data model for maps does not allow ascribing semantics to the
-order of the key/value pairs in the map representation.
-Thus, it would be a very bad practice to define a CBOR-based protocol
-in such a way that changing the key/value pair order in a map would
+order of the key/value pairs in the map representation.  Thus, a
+CBOR-based protocol MUST NOT specify that changing the key/value pair
+order in a map would
 change the semantics, apart from trivial aspects (cache usage, etc.).
 (A CBOR-based protocol can prescribe a specific order of
 serialization, such as for canonicalization.)

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -1344,10 +1344,9 @@ decoders that are using strict mode ({{strict-mode}}).
 The CBOR data model for maps does not allow ascribing semantics to the
 order of the key/value pairs in the map representation.  Thus, a
 CBOR-based protocol MUST NOT specify that changing the key/value pair
-order in a map would
-change the semantics, apart from trivial aspects (cache usage, etc.).
-(A CBOR-based protocol can prescribe a specific order of
-serialization, such as for canonicalization.)
+order in a map would change the semantics, except to specify that some,
+e.g. non-canonical, orders are ill-formed. Timing, cache usage, and
+other side channels are not considered part of the semantics.
 
 Applications for constrained devices that have maps with 24 or fewer
 frequently used keys should consider using small integers (and those


### PR DESCRIPTION
Except for being able to reject messages with a non-canonical order.