### PR TITLE
Tighten up epoch time requirements [no longer deprecate use of floating point]

### DIFF
--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -799,17 +799,19 @@ described in {{RFC3339}}, as refined by Section 3.3 of {{RFC4287}}.
 
 Tag value 1 is for numerical representation of time in seconds relative to 1970-01-01T00:00Z UTC. Support for tag value 1 is optional, but if it is supported the following “must” and “should” requirements apply. 
 
-The tagged item must be a positive integer (major type 0), negative integer (major type 1) or the simple value undef (major type 7, value 23) to indicate the time is not known. 
+The tagged item must be an unsigned integer (major type 0), negative integer (major type 1), or floating-point number (major type 7 with additional information 25, 26, or 27). 
 
-Positive values (major type 0 and positive floating-point numbers) must be computed according to POSIX [TIME_T]. POSIX time is also known as UNIX Epoch time. Note that leap seconds are taken into account by POSIX time and this results in a 1 second discontinuity about once a year. 32-bit integer values must be supported. These will cease to work in the year 2106, so 64-bit integers should also be supported.
+Unsigned values (major type 0 and positive floating-point numbers), values after 1970-01-01T00:00Z UTC, must be computed according to POSIX [TIME_T]. POSIX time is also known as UNIX Epoch time. Note that leap seconds are taken into account by POSIX time and this results in a 1 second discontinuity about once a year. 32-bit unsigned integer values must be supported. These will cease to work in the year 2106, so 64-bit unsigned integer values should also be supported.
 
 Negative values (major type 1 and negative floating-point numbers) are computed by “best practice” as determined by the implementor since there is no standard for count-of-seconds time encoding before 1970-01-01T00:00Z UTC time.
 
-When encoding, positive integer time values must be supported. The time value must always be encoded as short as possible. 
+If a CBOR protocol requires fractional seconds, floating point support can be added. Double-precision floating-point should always be supported. There is little point to supporting single-precious floating as it gives no advantage over 32-bit integers in range or precision, though to be “liberal in what you receive” single-precision floating point can be supported. 
 
-When decoding, positive integer time values must be supported. All integer representations of a particular value must be supported and must be considered equal (e.g., 0x03, 0x0003 and 0x00000003 must all be decoded and are all the same time).
+Floating-point representation should only be used if fractional second resolution is needed as it gives no advantage over 64-bit integers in range or compactness. The decision to use the floating-point representation should be made on a per-protocol basis not on a per message basis. For example, a protocol design might decide to never use floating point or to always use floating point representation.
 
-Floating point time was allowed with this tag in RFC 7049. It is deprecated and no longer allowed for this version of CBOR.
+When encoding tag 1, unsigned integer values must be supported. The time value should always be encoded as short as possible. 
+
+When decoding tag 1, positive integer time values must be supported. All integer representations of a particular value must be supported and considered equal (e.g., 0x03, 0x0003 and 0x00000003 are all the same). 
 
 ### Bignums {#bignums}
 

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -768,8 +768,8 @@ the rest of this section.
 
 |       Tag | Data Item    | Semantics                                                     |
 |-----------+--------------+---------------------------------------------------------------|
-|         0 | UTF-8 string | Standard date/time string; see {{datetimesect}}               |
-|         1 | multiple     | Epoch-based date/time; see {{datetimesect}}                   |
+|         0 | UTF-8 string | Standard date/time string; see {{stringdatetimesect}}               |
+|         1 | multiple     | Epoch-based date/time; see {{epochdatetimesect}}                   |
 |         2 | byte string  | Positive bignum; see {{bignums}}                              |
 |         3 | byte string  | Negative bignum; see {{bignums}}                              |
 |         4 | array        | Decimal fraction; see {{fractions}}                           |
@@ -790,24 +790,26 @@ the rest of this section.
 |    55800+ | (Unassigned) | (Unassigned)                                                  |
 {: #tagvalues title='Values for Tags'}
 
-### Date and Time {#datetimesect}
-
-Protocols using tag values 0 and 1 extend the generic data model
-({{cbor-data-models}}) with data items representing points in time.
+### String Date and Time {#stringdatetimesect}
 
 Tag value 0 is for date/time strings that follow the standard format
 described in {{RFC3339}}, as refined by Section 3.3 of {{RFC4287}}.
 
-Tag value 1 is for numerical representation of seconds relative to
-1970-01-01T00:00Z in UTC time.  (For the non-negative values that the
-Portable Operating System Interface (POSIX) defines, the number of
-seconds is counted in the same way as for POSIX "seconds since the
-epoch" {{TIME_T}}.)  The tagged item can be a positive or negative
-integer (major types 0 and 1), or a floating-point number (major type
-7 with additional information 25, 26, or 27). Note that the number can
-be negative (time before 1970-01-01T00:00Z) and, if a floating-point
-number, indicate fractional seconds.
+### Epoch Date and Time {#epochdatetimesect}
 
+Tag value 1 is for numerical representation of time in seconds relative to 1970-01-01T00:00Z UTC. Support for tag value 1 is optional, but if it is supported the following “must” and “should” requirements apply. 
+
+The tagged item must be a positive integer (major type 0), negative integer (major type 1) or the simple value undef (major type 7, value 23) to indicate the time is not known. 
+
+Positive values (major type 0 and positive floating-point numbers) must be computed according to POSIX [TIME_T]. POSIX time is also known as UNIX Epoch time. Note that leap seconds are taken into account by POSIX time and this results in a 1 second discontinuity about once a year. 32-bit integer values must be supported. These will cease to work in the year 2106, so 64-bit integers should also be supported.
+
+Negative values (major type 1 and negative floating-point numbers) are computed by “best practice” as determined by the implementor since there is no standard for count-of-seconds time encoding before 1970-01-01T00:00Z UTC time.
+
+When encoding, positive integer time values must be supported. The time value must always be encoded as short as possible. 
+
+When decoding, positive integer time values must be supported. All integer representations of a particular value must be supported and must be considered equal (e.g., 0x03, 0x0003 and 0x00000003 must all be decoded and are all the same time).
+
+Floating point time was allowed with this tag in RFC 7049. It is deprecated and no longer allowed for this version of CBOR.
 
 ### Bignums {#bignums}
 
@@ -2218,8 +2220,8 @@ unsigned integers are in network byte order.)
 |       0xba | map (four-byte uint32_t for n, and then n pairs of data items follow)  |
 |       0xbb | map (eight-byte uint64_t for n, and then n pairs of data items follow) |
 |       0xbf | map, pairs of data items follow, terminated by "break"                 |
-|       0xc0 | Text-based date/time (data item follows; see {{datetimesect}})         |
-|       0xc1 | Epoch-based date/time (data item follows; see {{datetimesect}})        |
+|       0xc0 | Text-based date/time (data item follows; see {{stringdatetimesect}})         |
+|       0xc1 | Epoch-based date/time (data item follows; see {{epochdatetimesect}})        |
 |       0xc2 | Positive bignum (data item "byte string" follows)                      |
 |       0xc3 | Negative bignum (data item "byte string" follows)                      |
 |       0xc4 | Decimal Fraction (data item "array" follows; see {{fractions}})        |


### PR DESCRIPTION
Goal is to remove as many implementation options for tag 1 epoch time as possible. Implementation options lead to more implementation work, confusion and interop problems.

I am proposing removal of floating point as an option because it doesn't provide that much benefit and there is a much easier / better way to get pretty much the same result of added precision.

Integer times pretty much cover it if you just need one second resolution:
  - 32-bit integers in CBOR cover from the year 1834 to 2106.
  - 64-bit integers cover +/- 584 billion years. The big bang was only 13 billion years ago.

Thus floating point is not necessary to deal with distant past and future times. A 64-bit int does that better than a double.

A float only has 23 bits of significand so it can only give more precision than a 32-bit int for a few months around 1970 and is thus useless.

A double has 52 bits of significand and can give microsecond resolution for dates up to the year 2100, but I think a 64-bit integer that marks time in microseconds or even nanoseconds is preferable. It would be a different tag value.
 - It doesn't require the CPU to have floating point support
 - The precision doesn't degrade as the time gets further from the epoch like it does with a double
 - It is keeps the implementation cleaner and consistent.

I'm also proposing that undef be allowed to indicate when the time is unknown.

The implementation choice left are:
 - 64-bit or not. 32-bit time is actually quite useful and some tiny 8-bit CPUs like those on Arduino's might have trouble if 64-bit was required.
 - Negative values are not required as they are not clearly defined and not that widely used.

I know this breaks compatibility with 7049.


