### PR TITLE
Clearly identify ill-formed and invalid items, and specify processor behavior on them

### DIFF
--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -409,7 +409,7 @@ floats as integers or vice versa, perhaps to save encoded bytes.
 
 A CBOR data item  ({{cbor-data-models}}) is encoded to or decoded from
 a byte string as described in this section.  The encoding is
-summarized in {{jumptable}}.  An encoder MUST produce only valid
+summarized in {{jumptable}}.  An encoder MUST produce only well-formed
 items.  A decoder MUST stop and return an error with no data when it
 encounters a non-well-formed item.
 
@@ -1074,7 +1074,8 @@ pair whose key is 0xab01".
 
 CBOR-based protocols MUST specify how their decoders handle
 invalid and other unexpected data.  CBOR-based protocols
-MAY specify that they treat arbitrary valid data as unexpected.  An
+MAY specify that they treat arbitrary valid data as unexpected.
+Encoders for CBOR-based protocols MUST produce only valid items. An
 encoder can be capable of encoding as many or as few types of values
 as is required by the protocol in which it is used; a decoder can be
 capable of understanding as many or as few types of values as is

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -547,7 +547,7 @@ referred to as "streaming" within a data item.)
 Indefinite-length arrays and maps are dealt with differently than
 indefinite-length byte strings and text strings.
 
-### The "break" stop code {#break}
+### The "break" Stop Code {#break}
 
 The "break" stop code is encoded with major type 7 and additional
 information value 31 (0b111_11111). It is not itself a data item: it

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -1263,12 +1263,19 @@ floating-point keys the values of which happen to be integer numbers in the same
 Decoders that deliver data items nested within a CBOR data item
 immediately on decoding them ("streaming decoders") often do not keep
 the state that is necessary to ascertain uniqueness of a key in a map.
-In this case, the surrounding application is responsible for satisfying
-the requirement that an non-well-formed map with duplicate keys is rejected.
 Similarly, an encoder that can start encoding data items before the
 enclosing data item is completely available ("streaming encoder") may
 want to reduce its overhead significantly by relying on its data
 source to maintain uniqueness.
+
+A CBOR-based protocol MUST define what
+to do when a receiving application does see multiple identical keys in
+a map.  The resulting rule in the protocol MUST respect the CBOR
+data model: it cannot prescribe a specific handling of the entries
+with the identical keys, except that it might have a rule that having
+identical keys in a map indicates a malformed map and that the decoder
+has to stop with an error. Duplicate keys are also prohibited by CBOR
+decoders that are using strict mode ({{strict-mode}}).
 
 The CBOR data model for maps does not allow ascribing semantics to the
 order of the key/value pairs in the map representation.  Thus, a
@@ -1519,6 +1526,8 @@ the effort to reliably detect invalid data items
 ({{semantic-errors}}). For example, a strict decoder needs to have an
 API that reports an error (and does not return data) for a CBOR data
 item that contains any of the following:
+
+* a map (major type 5) that has more than one entry with the same key
 
 * a tag that is used on a data item of the incorrect type
 

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -287,7 +287,8 @@ Well-formed:
 : A data item that follows the syntactic structure of CBOR.  A
   well-formed data item uses the initial bytes and the byte strings
   and/or data items that are implied by their values as defined in
-  CBOR and is not followed by extraneous data.
+  CBOR and is not followed by extraneous data. CBOR parsers only
+  return contents from well-formed data items.
 
 Valid:
 : A data item that is well-formed and also follows the semantic
@@ -408,27 +409,31 @@ floats as integers or vice versa, perhaps to save encoded bytes.
 
 A CBOR data item  ({{cbor-data-models}}) is encoded to or decoded from
 a byte string as described in this section.  The encoding is
-summarized in {{jumptable}}.
+summarized in {{jumptable}}.  An encoder MUST produce only valid
+items.  A decoder MUST stop and return an error with no data when it
+encounters a non-well-formed item.
 
 The initial byte of each encoded data item contains both information
 about the major type (the high-order 3 bits, described in
 {{majortypes}}) and additional information (the low-order 5 bits).
-Additional information value
-31 is used for indefinite-length items, described in {{indefinite}}.
-Additional information values 28 to 30 are reserved for future
-expansion.
+For major types except for 7, the additional information's value
+describes how to load an argument:
 
-Additional information values from 0 to 27 describes how to construct an
-"argument", possibly consuming additional bytes.  For major type 7 and
-additional information 25 to 27 (floating
-point numbers), there is a special case; in all other cases
-the additional information value, possibly combined with following
-bytes, the argument constructed is an unsigned integer.
+Less than 24:
+: The argument's value is the value of the additional information.
 
-When the value of the
-additional information is less than 24, it is directly used as the
-argument's value.  When it is 24 to 27, the argument's value is held
-in the following 1, 2, 4, or 8, respectively, bytes, in network byte order.
+24, 25, 26, or 27:
+: The argument's value is held in the following 1, 2, 4, or 8,
+  respectively, bytes, in network byte order.
+
+28, 29, 30:
+: These values are reserved for future expansion.  In this version of
+  CBOR, the encoded item is not well-formed.
+
+31:
+: If the major type is 0, 1, or 6, the encoded item is
+  not well-formed. Otherwise, the item's length is indefinite, as described
+  in {{indefinite}}.
 
 The meaning of this argument depends on the major type.
 For example, in major type 0, the argument is the value of the data
@@ -437,11 +442,11 @@ computed from the argument); in major type 2 and 3 it gives the length
 of the string data in bytes that follows; and in major types 4 and 5 it is used to
 determine the number of data items enclosed.
 
-If the encoded sequence of bytes ends before the end of a data item
-would be reached, that encoding is not well-formed. If the encoded
+If the encoded sequence of bytes ends before the end of a data item,
+that item is not well-formed. If the encoded
 sequence of bytes still has bytes remaining
-after the outermost encoded item is decoded, that encoding is not a
-single well-formed CBOR item.
+after the outermost encoded item is decoded, that outer item is
+not well-formed.
 
 A CBOR decoder implementation can be based on a jump table with all
 256 defined values for the initial byte ({{jumptable}}).  A decoder in
@@ -712,16 +717,19 @@ information is in the initial bytes.
 |          25 | IEEE 754 Half-Precision Float (16 bits follow)            |
 |          26 | IEEE 754 Single-Precision Float (32 bits follow)          |
 |          27 | IEEE 754 Double-Precision Float (64 bits follow)          |
-|       28-30 | (Unassigned)                                              |
+|       28-30 | Not well-formed                                           |
 |          31 | "break" stop code for indefinite-length items ({{break}}) |
 {: #fpnoconttbl title='Values for Additional Information in Major Type 7'}
 
 As with all other major types, the 5-bit value 24 signifies a
 single-byte extension: it is followed by an additional byte to
-represent the simple value. (To minimize confusion, only the values 32
-to 255 are used.)  This maintains the structure of the initial bytes:
+represent the simple value.  This maintains the structure of the
+initial bytes:
 as for the other major types, the length of these always depends on
-the additional information in the first byte. {{fpnoconttbl2}} lists
+the additional information in the first byte.  If a value between 0..31
+inclusive appears in this additional byte, the item is not well-formed.
+
+{{fpnoconttbl2}} lists
 the values assigned and available for simple types.
 
 |   Value | Semantics       |
@@ -735,18 +743,18 @@ the values assigned and available for simple types.
 | 32..255 | (Unassigned)    |
 {: #fpnoconttbl2 title='Simple Values'}
 
-The 5-bit values of 25, 26, and 27 are for 16-bit, 32-bit, and 64-bit
-IEEE 754 binary floating-point values {{-fp}}.  These floating-point values
-are encoded in the additional bytes of the appropriate size.  (See
-{{half-precision}} for some information about 16-bit floating point.)
-
-An encoder
+Specifically, an encoder
 MUST NOT encode False as the two-byte sequence of 0xf814,
 MUST NOT encode True as the two-byte sequence of 0xf815,
 MUST NOT encode Null as the two-byte sequence of 0xf816, and
 MUST NOT encode Undefined value as the two-byte sequence of 0xf817.
 A decoder MUST treat these two-byte sequences as an error.
 Similar prohibitions apply to the unassigned simple values as well.
+
+The 5-bit values of 25, 26, and 27 are for 16-bit, 32-bit, and 64-bit
+IEEE 754 binary floating-point values {{-fp}}.  These floating-point values
+are encoded in the additional bytes of the appropriate size.  (See
+{{half-precision}} for some information about 16-bit floating point.)
 
 ## Optional Tagging of Items {#tags}
 
@@ -759,8 +767,6 @@ data, this structure is encoded into the nested data item.  The
 definition of a tag usually restricts what kinds of nested data item
 or items are valid.
 
-The initial bytes of the tag follow the rules for positive integers
-(major type 0). The tag is followed by a single data item of any type.
 For example, assume that a byte string of length 12 is marked with a
 tag to indicate it is a positive bignum ({{bignums}}).  This would be
 marked as 0b110_00010 (major type 6, additional information 2 for the
@@ -1066,7 +1072,9 @@ subsequent values are zero or more floating-point numbers" or "the
 item is a map that has byte strings for keys and contains at least one
 pair whose key is 0xab01".
 
-This specification puts no restrictions on CBOR-based protocols. An
+CBOR-based protocols MUST specify how their decoders handle
+invalid and other unexpected data.  CBOR-based protocols
+MAY specify that they treat arbitrary valid data as unexpected.  An
 encoder can be capable of encoding as many or as few types of values
 as is required by the protocol in which it is used; a decoder can be
 capable of understanding as many or as few types of values as is
@@ -1075,9 +1083,7 @@ restrictions allows CBOR to be used in extremely constrained
 environments.
 
 This section discusses some considerations in creating CBOR-based
-protocols.  It is advisory only and explicitly excludes any language
-from RFC 2119 other than words that could be interpreted as "MAY" in
-the sense of RFC 2119.
+protocols.
 
 ## CBOR in Streaming Applications
 
@@ -1105,18 +1111,15 @@ applications but not others.
 ## Generic Encoders and Decoders {#generic}
 
 A generic CBOR decoder can decode all well-formed CBOR data and
-present them to an application.  CBOR data is well-formed if it uses
-the initial bytes, as well as the byte strings and/or data items that
-are implied by their values, in the manner defined by CBOR, and no
-extraneous data follows ({{pseudocode}}).
+present them to an application.  See {{pseudocode}}.
 
 Even though CBOR attempts to minimize these cases, not all well-formed
-CBOR data is valid: for example, the format excludes simple values
-below 32 that are encoded with an extension byte.  Also, specific tags
-may make semantic constraints that may be violated, such as by
-including a tag in a bignum tag or by following a byte string within a
-date tag.  Finally, the data may be invalid, such as invalid UTF-8
-strings or date strings that do not conform to {{RFC3339}}.  There is
+CBOR data is valid: for example, the text string `0x62c0ae` is not
+valid UTF-8 and so not a valid CBOR item.  Also, specific tags may
+make semantic constraints that may be violated, such as a bignum tag
+containing another tag, or a date tag containing a byte string or a
+text string with contents that don't match {{RFC3339}}'s `date-time`
+production.  There is
 no requirement that generic encoders and decoders make unnatural
 choices for their application interface to enable the processing of
 invalid data.  Generic encoders and decoders are expected to forward
@@ -1134,75 +1137,23 @@ application to specify any well-formed value, including simple values
 and tags unknown to the encoder.
 
 
-## Syntax Errors
+## Invalid Items {#semantic-errors}
 
-A decoder encountering a CBOR data item that is not well-formed
-generally can choose to completely fail the decoding (issue an error
-and/or stop processing altogether), substitute the problematic data
-and data items using a decoder-specific convention that clearly
-indicates there has been a problem, or take some other action.
+A well-formed but invalid CBOR data item presents a problem with
+interpreting the data encoded in it in the CBOR data model.  A
+CBOR-based protocol could be specified in several layers, in which the
+lower layers don't process the semantics of some of the CBOR data they
+forward.  These layers can't notice the invalidity in data they don't
+process and MUST forward that data as-is.  The first layer that does
+process the semantics of an invalid CBOR item MUST take one of two
+choices:
 
-### Incomplete CBOR Data Items
+1. Replace the problematic item with an error marker and continue with
+   the next item, or
+1. Issue an error and stop processing altogether.
 
-The representation of a CBOR data item has a specific length,
-determined by its initial bytes and by the structure of any data items
-enclosed in the data items.  If less data is available, this can be
-treated as a syntax error.  A decoder may also decode incrementally,
-that is, decode the data item as far as it is available and
-present the data found so far (such as in an event-based interface),
-with the option of continuing the decoding once further data is
-available.
-
-Examples of incomplete data items include:
-
-* A decoder expects a certain number of array or map entries but
-  instead encounters the end of the data.
-
-* A decoder processes what it expects to be the last pair in a map and
-  comes to the end of the data.
-
-* A decoder has just seen a tag and then encounters the end of the
-  data.
-
-* A decoder has seen the beginning of an indefinite-length item but
-  encounters the end of the data before it sees the "break" stop code.
-
-
-
-### Malformed Indefinite-Length Items
-
-Examples of malformed indefinite-length data items include:
-
-* Within an indefinite-length byte string or text, a decoder finds an
-  item that is not of the appropriate major type before it finds the
-  "break" stop code.
-
-* Within an indefinite-length map, a decoder encounters the "break"
-  stop code immediately after reading a key (the value is missing).
-
-Another error is finding a "break" stop code at a point in the data
-where there is no immediately enclosing (unclosed) indefinite-length
-item.
-
-
-### Unknown Additional Information Values
-
-At the time of writing, some additional information values are
-unassigned and reserved for future versions of this document (see
-{{curating}}).  Since the overall syntax for these additional
-information values is not yet defined, a decoder that sees an
-additional information value that it does not understand cannot
-continue decoding.
-
-
-## Other Decoding Errors {#semantic-errors}
-
-A CBOR data item may be syntactically well-formed but present a
-problem with interpreting the data encoded in it in the CBOR data
-model.  Generally speaking, a decoder that finds a data item with such
-a problem might issue a warning, might stop processing altogether,
-might handle the error and make the problematic value available to the
-application as such, or take some other type of action.
+A CBOR-based protocol MUST specify which of these options its decoders
+take, for each kind of invalid item they might encounter.
 
 Such problems might include:
 
@@ -1253,14 +1204,6 @@ item only to the application, or take some other type of action.
 
 
 ## Numbers {#numbers}
-
-An application or protocol that uses CBOR might restrict the
-representations of numbers.  For instance, a protocol that only deals
-with integers might say that floating-point numbers may not be used
-and that decoders of that protocol do not need to be able to handle
-floating-point numbers. Similarly, a protocol or application that uses
-CBOR might say that decoders need to be able to handle either type of
-number.
 
 CBOR-based protocols should take into account that different language
 environments pose different restrictions on the range and precision of
@@ -1319,19 +1262,12 @@ floating-point keys the values of which happen to be integer numbers in the same
 Decoders that deliver data items nested within a CBOR data item
 immediately on decoding them ("streaming decoders") often do not keep
 the state that is necessary to ascertain uniqueness of a key in a map.
+In this case, the surrounding application is responsible for satisfying
+the requirement that an non-well-formed map with duplicate keys is rejected.
 Similarly, an encoder that can start encoding data items before the
 enclosing data item is completely available ("streaming encoder") may
 want to reduce its overhead significantly by relying on its data
 source to maintain uniqueness.
-
-A CBOR-based protocol should make an intentional decision about what
-to do when a receiving application does see multiple identical keys in
-a map.  The resulting rule in the protocol should respect the CBOR
-data model: it cannot prescribe a specific handling of the entries
-with the identical keys, except that it might have a rule that having
-identical keys in a map indicates a malformed map and that the decoder
-has to stop with an error. Duplicate keys are also prohibited by CBOR
-decoders that are using strict mode ({{strict-mode}}).
 
 The CBOR data model for maps does not allow ascribing semantics to the
 order of the key/value pairs in the map representation.  Thus, a
@@ -1577,14 +1513,11 @@ that firewalls and other security systems that decode CBOR will only
 decode in strict mode.
 
 A decoder in strict mode will reliably reject any data that could be
-interpreted by other decoders in different ways.  It will reliably
-reject data items with syntax errors ({{syntax-errors}}).  It will
-also expend the effort to reliably detect other decoding errors
-({{semantic-errors}}). In particular, a strict decoder needs to have
-an API that reports an error (and does not return data) for a CBOR
-data item that contains any of the following:
-
-* a map (major type 5) that has more than one entry with the same key
+interpreted by other decoders in different ways.  It will expend
+the effort to reliably detect invalid data items
+({{semantic-errors}}). For example, a strict decoder needs to have an
+API that reports an error (and does not return data) for a CBOR data
+item that contains any of the following:
 
 * a tag that is used on a data item of the incorrect type
 

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -547,27 +547,27 @@ referred to as "streaming" within a data item.)
 Indefinite-length arrays and maps are dealt with differently than
 indefinite-length byte strings and text strings.
 
+### The "break" stop code {#break}
+
+The "break" stop code is encoded with major type 7 and additional
+information value 31 (0b111_11111). It is not itself a data item: it
+is just a syntactic feature to close an indefinite-length item.
+
+If the "break" stop code appears anywhere other than directly inside
+an indefinite-length string, array, or map—for example directly inside
+a definite-length array or map—the enclosing item is not well-formed.
+
 ### Indefinite-Length Arrays and Maps
 
-Indefinite-length arrays and maps are simply opened without indicating
-the number of data items that will be included in the array or map,
-using the additional information value of 31. The initial major type
-and additional information byte is followed by the elements of the
-array or map, just as they would be in other arrays or maps. The end
-of the array or map is indicated by encoding a "break" stop code in a
-place where the next data item would normally have been included.  The
-"break" is encoded with major type 7 and additional information value
-31 (0b111_11111) but is not itself a data item: it is just a syntactic
-feature to close the array or map.  That is, the "break" stop code
-comes after the last item in the array or map, and it cannot occur
-anywhere else in place of a data item. In this way, indefinite-length
-arrays and maps look identical to other arrays and maps except for
-beginning with the additional information value 31 and ending with the
-"break" stop code.
+Indefinite-length arrays and maps are represented using their major
+type with the additional information value of 31, followed by an
+arbitrary-length sequence of items for an array or key/value pairs for
+a map, followed by the "break" stop code ({{break}}).
 
-Arrays and maps with indefinite lengths allow any number of items (for
-arrays) and key/value pairs (for maps) to be given before the "break"
-stop code.  There is no restriction against nesting indefinite-length
+If the break stop code appears after a key in a map, in place of that
+key's value, the map is not well-formed.
+
+There is no restriction against nesting indefinite-length
 array or map items.  A "break" only terminates a single item, so
 nested indefinite-length items need exactly as many "break" stop codes
 as there are type bytes starting an indefinite-length item.
@@ -663,26 +663,21 @@ BF           -- Start indefinite-length map
 
 ### Indefinite-Length Byte Strings and Text Strings
 
-Indefinite-length byte strings and text strings are actually a
-concatenation of zero or more definite-length byte or text strings
-("chunks") that are together treated as one contiguous
-string. Indefinite-length strings are opened with the major type and
-additional information value of 31, but what follows are a series of
-byte or text strings that have definite lengths (the chunks). The end
-of the series of chunks is indicated by encoding the "break" stop code
-(0b111_11111) in a place where the next chunk in the series would
-occur. The contents of the chunks are concatenated together, and the
-overall length of the indefinite-length string will be the sum of the
-lengths of all of the chunks.  In summary, an indefinite-length string
-is encoded similarly to how an indefinite-length array of its chunks
-would be encoded, except that the major type of the indefinite-length
-string is that of a (text or byte) string and matches the major types
-of its chunks.
+Indefinite-length strings consist of a byte containing the major type
+and additional information value of 31, followed by a series of byte
+or text strings ("chunks") that have definite lengths, followed by the
+"break" stop code ({{break}}).  The data item represented by the
+indefinite-length string is the concatenation of the chunks.
 
-For indefinite-length byte strings, every data item (chunk) between
-the indefinite-length indicator and the "break" MUST be a
-definite-length byte string item; if the decoder sees any item type
-other than a byte string before it sees the "break", it is an error.
+If any item between the indefinite-length string indicator
+(0b010_11111 or 0b011_11111) and the "break" is not a definite-length
+string item of the same major type, the string is not well-formed.
+
+If any definite-length text string inside an indefinite-length text
+string is invalid, the indefinite-length text string is invalid.  Note
+that this implies that the bytes of a single UTF-8 character cannot be
+spread between chunks: a new chunk can only be started at a character
+boundary.
 
 For example, assume the sequence:
 
@@ -700,12 +695,6 @@ For example, assume the sequence:
 After decoding, this results in a single byte string with seven bytes:
 0xaabbccddeeff99.
 
-Text strings with indefinite lengths act the same as byte strings with
-indefinite lengths, except that all their chunks MUST be
-definite-length text strings.  Note that this implies that the bytes
-of a single UTF-8 character cannot be spread between chunks: a new
-chunk can only be started at a character boundary.
-
 
 ## Floating-Point Numbers and Values with No Content {#fpnocont}
 
@@ -716,15 +705,15 @@ meaning, as defined in {{fpnoconttbl}}.  Like the major types for
 integers, items of this major type do not carry content data; all the
 information is in the initial bytes.
 
-| 5-Bit Value | Semantics                                        |
-|-------------+--------------------------------------------------|
-|       0..23 | Simple value (value 0..23)                       |
-|          24 | Simple value (value 32..255 in following byte)   |
-|          25 | IEEE 754 Half-Precision Float (16 bits follow)   |
-|          26 | IEEE 754 Single-Precision Float (32 bits follow) |
-|          27 | IEEE 754 Double-Precision Float (64 bits follow) |
-|       28-30 | (Unassigned)                                     |
-|          31 | "break" stop code for indefinite-length items    |
+| 5-Bit Value | Semantics                                                 |
+|-------------+-----------------------------------------------------------|
+|       0..23 | Simple value (value 0..23)                                |
+|          24 | Simple value (value 32..255 in following byte)            |
+|          25 | IEEE 754 Half-Precision Float (16 bits follow)            |
+|          26 | IEEE 754 Single-Precision Float (32 bits follow)          |
+|          27 | IEEE 754 Double-Precision Float (64 bits follow)          |
+|       28-30 | (Unassigned)                                              |
+|          31 | "break" stop code for indefinite-length items ({{break}}) |
 {: #fpnoconttbl title='Values for Additional Information in Major Type 7'}
 
 As with all other major types, the 5-bit value 24 signifies a


### PR DESCRIPTION
This fixes #3 but, as requested in https://datatracker.ietf.org/doc/minutes-interim-2018-cbor-04-201809191500/, doesn't distinguish between recoverable ill-formed items and fatal ill-formed items. Anything ill-formed is required to stop the parser.