### PR TITLE
Cleanup by removing 5.8

### DIFF
--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -15,6 +15,8 @@ pi:
   compact: 'no'
   subcompact: 'no'
   rfcedstyle: 'yes'
+# reduce number of gratuitous differences from v2 to v3:
+#  text-list-symbols: '*-o+'
 title: Concise Binary Object Representation (CBOR)
 abbrev: CBOR
 area: Internet


### PR DESCRIPTION
Remove section 5.8 (and reuse some of its contents in 5.3).

Close #67 (debatable, see there).

Close #122 (but do *not* start a firewall section); "firewall" now
occurs exactly once.
