### PR TITLE
"Character"->"code point" when talking about UTF-8 validity.

### DIFF
--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -757,9 +757,9 @@ string item of the same major type, the string is not well-formed.
 
 If any definite-length text string inside an indefinite-length text
 string is invalid, the indefinite-length text string is invalid.  Note
-that this implies that the bytes of a single UTF-8 code point cannot be
-spread between chunks: a new chunk of a text string can only be
-started at a code point boundary.
+that this implies that the UTF-8 bytes of a single Unicode code point
+(scalar value) cannot be spread between chunks: a new chunk of a text
+string can only be started at a code point boundary.
 
 For example, assume an encoded data item consisting of the bytes:
 

--- a/draft-ietf-cbor-7049bis.md
+++ b/draft-ietf-cbor-7049bis.md
@@ -757,9 +757,9 @@ string item of the same major type, the string is not well-formed.
 
 If any definite-length text string inside an indefinite-length text
 string is invalid, the indefinite-length text string is invalid.  Note
-that this implies that the bytes of a single UTF-8 character cannot be
-split up between chunks: a new chunk of a text string can only be
-started at a character boundary.
+that this implies that the bytes of a single UTF-8 code point cannot be
+spread between chunks: a new chunk of a text string can only be
+started at a code point boundary.
 
 For example, assume an encoded data item consisting of the bytes:
 


### PR DESCRIPTION
"Character" is an ambiguous term in Unicode, often best understood as an
extended grapheme cluster, but a valid indefinite-length CBOR text string could
break an EGC between chunks. It's only code points that can't be split.

There are several more uses of "character" in the text, most of which I think it would be *correct* to change to "code point", but I think this is the only one where an understanding as "grapheme cluster" would give the reader the wrong understanding of CBOR's requirements.